### PR TITLE
Add dedicated memory controls and sequential recall

### DIFF
--- a/GraphCalc/MainForm.Designer.cs
+++ b/GraphCalc/MainForm.Designer.cs
@@ -12,9 +12,12 @@ public partial class MainForm
 {
     private const int ButtonCornerRadius = 12;
 
+    private Label OperationLabel = null!;
     private TextBox DisplayTextBox = null!;
     private TableLayoutPanel LayoutPanel = null!;
     private CheckBox ThemeToggleCheckBox = null!;
+    private Label HistoryLabel = null!;
+    private ListBox HistoryListBox = null!;
 
     private void InitializeComponent()
     {
@@ -23,7 +26,7 @@ public partial class MainForm
         LayoutPanel = new TableLayoutPanel
         {
             ColumnCount = 4,
-            RowCount = 8,
+            RowCount = 11,
             Dock = DockStyle.Fill,
             Padding = new Padding(8),
             BackColor = Color.FromArgb(245, 245, 245)
@@ -35,10 +38,13 @@ public partial class MainForm
         }
 
         LayoutPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
-        LayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 22F));
-        for (var i = 2; i < LayoutPanel.RowCount; i++)
+        LayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 20F));
+        LayoutPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        LayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 18F));
+        LayoutPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        for (var i = 5; i < LayoutPanel.RowCount; i++)
         {
-            LayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 13F));
+            LayoutPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 10.333F));
         }
 
         ThemeToggleCheckBox = new CheckBox
@@ -53,6 +59,27 @@ public partial class MainForm
         LayoutPanel.Controls.Add(ThemeToggleCheckBox, 0, 0);
         LayoutPanel.SetColumnSpan(ThemeToggleCheckBox, 4);
 
+        var displayPanel = new TableLayoutPanel
+        {
+            ColumnCount = 1,
+            RowCount = 2,
+            Dock = DockStyle.Fill,
+            Margin = new Padding(0, 0, 0, 8),
+            BackColor = Color.Transparent
+        };
+        displayPanel.RowStyles.Add(new RowStyle(SizeType.AutoSize));
+        displayPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
+
+        OperationLabel = new Label
+        {
+            Dock = DockStyle.Fill,
+            Font = new Font("Segoe UI", 12F, FontStyle.Regular, GraphicsUnit.Point),
+            TextAlign = ContentAlignment.BottomRight,
+            Margin = new Padding(0),
+            AutoSize = false
+        };
+        displayPanel.Controls.Add(OperationLabel, 0, 0);
+
         DisplayTextBox = new TextBox
         {
             Dock = DockStyle.Fill,
@@ -61,45 +88,95 @@ public partial class MainForm
             TextAlign = HorizontalAlignment.Right,
             BorderStyle = BorderStyle.FixedSingle,
             BackColor = Color.White,
-            Margin = new Padding(0, 0, 0, 8),
+            Margin = new Padding(0),
             TabStop = false
         };
-        LayoutPanel.Controls.Add(DisplayTextBox, 0, 1);
-        LayoutPanel.SetColumnSpan(DisplayTextBox, 4);
+        displayPanel.Controls.Add(DisplayTextBox, 0, 1);
 
-        AddButton("sin", OnUnaryOperationClick, 0, 2, tag: "sin");
-        AddButton("cos", OnUnaryOperationClick, 1, 2, tag: "cos");
-        AddButton("√", OnUnaryOperationClick, 2, 2, tag: "sqrt");
-        AddButton("n!", OnUnaryOperationClick, 3, 2, tag: "fact");
+        LayoutPanel.Controls.Add(displayPanel, 0, 1);
+        LayoutPanel.SetColumnSpan(displayPanel, 4);
 
-        AddButton("CE", OnClearEntryClick, 0, 3);
-        AddButton("C", OnClearAllClick, 1, 3);
-        AddButton("⌫", OnBackspaceClick, 2, 3, tag: "Backspace");
-        AddButton("÷", OnOperatorClick, 3, 3, tag: "/");
+        HistoryLabel = new Label
+        {
+            Dock = DockStyle.Fill,
+            Text = "Memória",
+            Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point),
+            Margin = new Padding(0, 0, 0, 4),
+            AutoSize = false,
+            TextAlign = ContentAlignment.MiddleLeft
+        };
+        LayoutPanel.Controls.Add(HistoryLabel, 0, 2);
+        LayoutPanel.SetColumnSpan(HistoryLabel, 4);
 
-        AddButton("7", OnDigitClick, 0, 4);
-        AddButton("8", OnDigitClick, 1, 4);
-        AddButton("9", OnDigitClick, 2, 4);
-        AddButton("×", OnOperatorClick, 3, 4, tag: "*");
+        HistoryListBox = new ListBox
+        {
+            Dock = DockStyle.Fill,
+            Font = new Font("Segoe UI", 10F, FontStyle.Regular, GraphicsUnit.Point),
+            Margin = new Padding(0, 0, 0, 8),
+            IntegralHeight = false,
+            SelectionMode = SelectionMode.One
+        };
+        HistoryListBox.SelectedIndexChanged += OnHistorySelectedIndexChanged;
+        LayoutPanel.Controls.Add(HistoryListBox, 0, 3);
+        LayoutPanel.SetColumnSpan(HistoryListBox, 4);
 
-        AddButton("4", OnDigitClick, 0, 5);
-        AddButton("5", OnDigitClick, 1, 5);
-        AddButton("6", OnDigitClick, 2, 5);
-        AddButton("-", OnOperatorClick, 3, 5);
+        var memoryButtonPanel = new TableLayoutPanel
+        {
+            ColumnCount = 3,
+            RowCount = 1,
+            Dock = DockStyle.Fill,
+            Margin = new Padding(0, 0, 0, 8)
+        };
+        memoryButtonPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.333F));
+        memoryButtonPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.333F));
+        memoryButtonPanel.ColumnStyles.Add(new ColumnStyle(SizeType.Percent, 33.334F));
+        memoryButtonPanel.RowStyles.Add(new RowStyle(SizeType.Percent, 100F));
 
-        AddButton("1", OnDigitClick, 0, 6);
-        AddButton("2", OnDigitClick, 1, 6);
-        AddButton("3", OnDigitClick, 2, 6);
-        AddButton("+", OnOperatorClick, 3, 6);
+        var memoryAddButton = CreateButton("Memória +", OnMemoryStoreClick, "memory-add");
+        memoryButtonPanel.Controls.Add(memoryAddButton, 0, 0);
 
-        AddButton("±", OnToggleSignClick, 0, 7);
-        AddButton("0", OnDigitClick, 1, 7);
-        AddButton(",", OnDecimalClick, 2, 7);
-        AddButton("=", OnEqualsClick, 3, 7);
+        var memoryShowButton = CreateButton("Memória megj.", OnMemoryRecallClick, "memory-show");
+        memoryButtonPanel.Controls.Add(memoryShowButton, 1, 0);
+
+        var memoryDeleteButton = CreateButton("Memória törlés", OnMemoryDeleteClick, "memory-delete");
+        memoryButtonPanel.Controls.Add(memoryDeleteButton, 2, 0);
+
+        LayoutPanel.Controls.Add(memoryButtonPanel, 0, 4);
+        LayoutPanel.SetColumnSpan(memoryButtonPanel, 4);
+
+        AddButton("sin", OnUnaryOperationClick, 0, 5, tag: "sin");
+        AddButton("cos", OnUnaryOperationClick, 1, 5, tag: "cos");
+        AddButton("√", OnUnaryOperationClick, 2, 5, tag: "sqrt");
+        AddButton("n!", OnUnaryOperationClick, 3, 5, tag: "fact");
+
+        AddButton("CE", OnClearEntryClick, 0, 6);
+        AddButton("C", OnClearAllClick, 1, 6);
+        AddButton("⌫", OnBackspaceClick, 2, 6, tag: "Backspace");
+        AddButton("÷", OnOperatorClick, 3, 6, tag: "/");
+
+        AddButton("7", OnDigitClick, 0, 7);
+        AddButton("8", OnDigitClick, 1, 7);
+        AddButton("9", OnDigitClick, 2, 7);
+        AddButton("×", OnOperatorClick, 3, 7, tag: "*");
+
+        AddButton("4", OnDigitClick, 0, 8);
+        AddButton("5", OnDigitClick, 1, 8);
+        AddButton("6", OnDigitClick, 2, 8);
+        AddButton("-", OnOperatorClick, 3, 8);
+
+        AddButton("1", OnDigitClick, 0, 9);
+        AddButton("2", OnDigitClick, 1, 9);
+        AddButton("3", OnDigitClick, 2, 9);
+        AddButton("+", OnOperatorClick, 3, 9);
+
+        AddButton("±", OnToggleSignClick, 0, 10);
+        AddButton("0", OnDigitClick, 1, 10);
+        AddButton(",", OnDecimalClick, 2, 10);
+        AddButton("=", OnEqualsClick, 3, 10);
 
         AutoScaleDimensions = new SizeF(7F, 15F);
         AutoScaleMode = AutoScaleMode.Font;
-        ClientSize = new Size(320, 520);
+        ClientSize = new Size(320, 560);
         Controls.Add(LayoutPanel);
         FormBorderStyle = FormBorderStyle.FixedDialog;
         MaximizeBox = false;

--- a/GraphCalc/MainForm.cs
+++ b/GraphCalc/MainForm.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
 using System.Windows.Forms;
@@ -9,10 +10,17 @@ public partial class MainForm : Form
 {
     private const char DisplayDecimalSeparator = ',';
 
+    private const int HistoryCapacity = 10;
+
     private double? _pendingValue;
     private string? _pendingOperator;
     private bool _shouldResetDisplay;
     private bool _isDarkMode;
+
+    private sealed record MemoryEntry(string Operation, string Result);
+
+    private readonly List<MemoryEntry> _memoryEntries = new();
+    private int _memoryDisplayIndex = -1;
 
     // Magyar komment: az ablak inicializálása és a kijelző alaphelyzetbe állítása
     public MainForm()
@@ -94,6 +102,10 @@ public partial class MainForm : Form
         {
             var result = Evaluate(_pendingValue.Value, current, _pendingOperator);
             UpdateDisplayFromDouble(result);
+            var operationText = $"{FormatDouble(_pendingValue.Value)} {GetDisplayOperator(_pendingOperator)} {FormatDouble(current)} =";
+            var resultText = FormatDouble(result);
+            UpdateOperationLabel(operationText);
+            AddToMemory(new MemoryEntry(operationText, resultText));
             _pendingValue = null;
             _pendingOperator = null;
             _shouldResetDisplay = true;
@@ -105,6 +117,7 @@ public partial class MainForm : Form
         // Magyar komment: csak az aktuális bevitelt töröljük
         UpdateDisplay("0");
         _shouldResetDisplay = true;
+        UpdateOperationLabel(string.Empty);
     }
 
     private void OnClearAllClick(object? sender, EventArgs e)
@@ -114,6 +127,7 @@ public partial class MainForm : Form
         _pendingValue = null;
         _pendingOperator = null;
         _shouldResetDisplay = false;
+        UpdateOperationLabel(string.Empty);
     }
 
     private void OnBackspaceClick(object? sender, EventArgs e)
@@ -179,7 +193,106 @@ public partial class MainForm : Form
         };
 
         UpdateDisplayFromDouble(result);
+        var operationText = operation switch
+        {
+            "sin" => $"sin({FormatDouble(current)}) =",
+            "cos" => $"cos({FormatDouble(current)}) =",
+            "sqrt" => $"√({FormatDouble(current)}) =",
+            "fact" => $"n!({FormatDouble(current)}) =",
+            _ => string.Empty
+        };
+
+        UpdateOperationLabel(operationText);
+
+        if (!string.IsNullOrEmpty(operationText))
+        {
+            AddToMemory(new MemoryEntry(operationText, FormatDouble(result)));
+        }
+
         _shouldResetDisplay = true;
+    }
+
+    private void OnMemoryRecallClick(object? sender, EventArgs e)
+    {
+        if (_memoryEntries.Count == 0)
+        {
+            return;
+        }
+
+        if (_memoryDisplayIndex < 0)
+        {
+            _memoryDisplayIndex = 0;
+        }
+        else if (_memoryDisplayIndex < _memoryEntries.Count - 1)
+        {
+            _memoryDisplayIndex++;
+        }
+
+        ShowMemoryEntry(_memoryDisplayIndex);
+    }
+
+    private void OnMemoryStoreClick(object? sender, EventArgs e)
+    {
+        if (!TryGetDisplayValue(out var value))
+        {
+            return;
+        }
+
+        var operationText = string.IsNullOrWhiteSpace(OperationLabel.Text)
+            ? "Eredmény ="
+            : OperationLabel.Text.Trim();
+        var resultText = FormatDouble(value);
+        AddToMemory(new MemoryEntry(operationText, resultText));
+    }
+
+    private void OnMemoryDeleteClick(object? sender, EventArgs e)
+    {
+        if (_memoryEntries.Count == 0)
+        {
+            return;
+        }
+
+        var wasViewingMemory = _memoryDisplayIndex >= 0;
+        var index = wasViewingMemory && _memoryDisplayIndex < _memoryEntries.Count
+            ? _memoryDisplayIndex
+            : 0;
+
+        _memoryEntries.RemoveAt(index);
+
+        if (_memoryEntries.Count == 0)
+        {
+            _memoryDisplayIndex = -1;
+            RefreshMemoryList();
+            return;
+        }
+
+        if (!wasViewingMemory)
+        {
+            _memoryDisplayIndex = -1;
+            RefreshMemoryList();
+            return;
+        }
+
+        if (index >= _memoryEntries.Count)
+        {
+            index = _memoryEntries.Count - 1;
+        }
+
+        _memoryDisplayIndex = index;
+        RefreshMemoryList();
+        ShowMemoryEntry(_memoryDisplayIndex);
+    }
+
+    private void OnHistorySelectedIndexChanged(object? sender, EventArgs e)
+    {
+        if (HistoryListBox.SelectedIndex >= 0 && HistoryListBox.SelectedIndex < _memoryEntries.Count)
+        {
+            _memoryDisplayIndex = HistoryListBox.SelectedIndex;
+        }
+        else
+        {
+            _memoryDisplayIndex = -1;
+        }
     }
 
     private static double CalculateFactorial(double value)
@@ -233,6 +346,13 @@ public partial class MainForm : Form
         LayoutPanel.BackColor = panelBackColor;
         DisplayTextBox.BackColor = displayBackColor;
         DisplayTextBox.ForeColor = displayForeColor;
+        OperationLabel.ForeColor = _isDarkMode ? Color.Gainsboro : Color.DimGray;
+
+        HistoryLabel.ForeColor = _isDarkMode ? Color.White : Color.Black;
+        HistoryLabel.BackColor = Color.Transparent;
+        HistoryListBox.BackColor = _isDarkMode ? Color.FromArgb(30, 30, 30) : Color.White;
+        HistoryListBox.ForeColor = _isDarkMode ? Color.White : Color.Black;
+        HistoryListBox.BorderStyle = BorderStyle.FixedSingle;
 
         ThemeToggleCheckBox.ForeColor = _isDarkMode ? Color.White : Color.Black;
         ThemeToggleCheckBox.BackColor = Color.Transparent;
@@ -307,10 +427,20 @@ public partial class MainForm : Form
     private void UpdateDisplayFromDouble(double value)
     {
         // Magyar komment: a lebegőpontos eredményt rendezett formátumban jelenítjük meg
+        UpdateDisplay(FormatDouble(value));
+    }
+
+    private void UpdateDisplay(string value)
+    {
+        // Magyar komment: a kijelzőt frissítjük, és a pontot vesszőre cseréljük
+        DisplayTextBox.Text = value.Replace('.', DisplayDecimalSeparator);
+    }
+
+    private string FormatDouble(double value)
+    {
         if (double.IsNaN(value) || double.IsInfinity(value))
         {
-            UpdateDisplay(value.ToString(CultureInfo.InvariantCulture));
-            return;
+            return value.ToString(CultureInfo.InvariantCulture);
         }
 
         var formatted = value.ToString("G15", CultureInfo.InvariantCulture);
@@ -320,12 +450,68 @@ public partial class MainForm : Form
             formatted = "0";
         }
 
-        UpdateDisplay(formatted);
+        return formatted.Replace('.', DisplayDecimalSeparator);
     }
 
-    private void UpdateDisplay(string value)
+    private static string GetDisplayOperator(string op) => op switch
     {
-        // Magyar komment: a kijelzőt frissítjük, és a pontot vesszőre cseréljük
-        DisplayTextBox.Text = value.Replace('.', DisplayDecimalSeparator);
+        "*" => "×",
+        "/" => "÷",
+        _ => op
+    };
+
+    private void UpdateOperationLabel(string text)
+    {
+        OperationLabel.Text = text;
+    }
+
+    private void AddToMemory(MemoryEntry entry)
+    {
+        _memoryEntries.Insert(0, entry);
+        if (_memoryEntries.Count > HistoryCapacity)
+        {
+            _memoryEntries.RemoveAt(_memoryEntries.Count - 1);
+        }
+
+        _memoryDisplayIndex = -1;
+        RefreshMemoryList();
+    }
+
+    private void ShowMemoryEntry(int index)
+    {
+        if (index < 0 || index >= _memoryEntries.Count)
+        {
+            return;
+        }
+
+        var entry = _memoryEntries[index];
+        UpdateOperationLabel(entry.Operation);
+        UpdateDisplay(entry.Result);
+        _pendingValue = null;
+        _pendingOperator = null;
+        _shouldResetDisplay = true;
+
+        _memoryDisplayIndex = index;
+        HistoryListBox.SelectedIndex = index;
+    }
+
+    private void RefreshMemoryList()
+    {
+        HistoryListBox.BeginUpdate();
+        HistoryListBox.Items.Clear();
+        foreach (var entry in _memoryEntries)
+        {
+            HistoryListBox.Items.Add($"{entry.Operation} {entry.Result}".Trim());
+        }
+        HistoryListBox.EndUpdate();
+
+        if (_memoryDisplayIndex >= 0 && _memoryDisplayIndex < _memoryEntries.Count)
+        {
+            HistoryListBox.SelectedIndex = _memoryDisplayIndex;
+        }
+        else
+        {
+            HistoryListBox.ClearSelected();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add a memory control row with dedicated add, display, and delete buttons in the keypad layout
- refactor memory storage to structured entries that synchronize with the on-screen list
- implement sequential memory recall cycling and context-aware deletion handling

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3163cb0483259e493fd5fc274779