### PR TITLE
Fix memory history selection to display entries

### DIFF
--- a/GraphCalc/MainForm.cs
+++ b/GraphCalc/MainForm.cs
@@ -326,14 +326,19 @@ public partial class MainForm : Form
 
     private void OnHistorySelectedIndexChanged(object? sender, EventArgs e)
     {
-        if (HistoryListBox.SelectedIndex >= 0 && HistoryListBox.SelectedIndex < _memoryEntries.Count)
+        var selectedIndex = HistoryListBox.SelectedIndex;
+
+        if (selectedIndex >= 0 && selectedIndex < _memoryEntries.Count)
         {
-            _memoryDisplayIndex = HistoryListBox.SelectedIndex;
+            if (_memoryDisplayIndex != selectedIndex)
+            {
+                ShowMemoryEntry(selectedIndex);
+            }
+
+            return;
         }
-        else
-        {
-            _memoryDisplayIndex = -1;
-        }
+
+        _memoryDisplayIndex = -1;
     }
 
     private static double CalculateFactorial(double value)


### PR DESCRIPTION
## Summary
- ensure selecting an item in the history list displays the stored calculation
- keep the internal memory index in sync without triggering redundant updates

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dffee507288325a0f1b171b75b2884