### PR TITLE
Fix Hungarian labels and math symbols

### DIFF
--- a/GraphCalc/MainForm.Designer.cs
+++ b/GraphCalc/MainForm.Designer.cs
@@ -54,7 +54,7 @@ public partial class MainForm
             Anchor = AnchorStyles.Top | AnchorStyles.Right,
             AutoSize = true,
             Margin = new Padding(0, 0, 4, 4),
-            Text = "S\\u00F6t\\u00E9t m\\u00F3d",
+            Text = "Sötét mód",
             UseVisualStyleBackColor = false
         };
         ThemeToggleCheckBox.CheckedChanged += OnThemeToggleCheckedChanged;
@@ -101,7 +101,7 @@ public partial class MainForm
         HistoryLabel = new Label
         {
             Dock = DockStyle.Fill,
-            Text = "Mem\\u00F3ria",
+            Text = "Memória",
             Font = new Font("Segoe UI", 9F, FontStyle.Bold, GraphicsUnit.Point),
             Margin = new Padding(0, 0, 0, 4),
             AutoSize = false,
@@ -129,23 +129,23 @@ public partial class MainForm
         AddButton("sin", OnUnaryOperationClick, 0, 5, tag: "sin");
         AddButton("cos", OnUnaryOperationClick, 1, 5, tag: "cos");
         AddButton("tan", OnUnaryOperationClick, 2, 5, tag: "tan");
-        AddButton("\\u221A", OnUnaryOperationClick, 3, 5, tag: "sqrt");
+        AddButton("\u221A", OnUnaryOperationClick, 3, 5, tag: "sqrt");
 
         AddButton("n!", OnUnaryOperationClick, 0, 6, tag: "fact");
         AddButton("%", OnPercentClick, 1, 6, tag: "%");
         AddButton("CE", OnClearEntryClick, 2, 6);
         AddButton("C", OnClearAllClick, 3, 6);
 
-        var backspaceButton = CreateButton("\\u232B", OnBackspaceClick, "Backspace");
+        var backspaceButton = CreateButton("\u232B", OnBackspaceClick, "Backspace");
         LayoutPanel.Controls.Add(backspaceButton, 0, 7);
         LayoutPanel.SetColumnSpan(backspaceButton, 3);
-        var divideButton = CreateButton("\\u00F7", OnOperatorClick, "/");
+        var divideButton = CreateButton("\u00F7", OnOperatorClick, "/");
         LayoutPanel.Controls.Add(divideButton, 3, 7);
 
         AddButton("7", OnDigitClick, 0, 8);
         AddButton("8", OnDigitClick, 1, 8);
         AddButton("9", OnDigitClick, 2, 8);
-        AddButton("\\u00D7", OnOperatorClick, 3, 8, tag: "*");
+        AddButton("\u00D7", OnOperatorClick, 3, 8, tag: "*");
 
         AddButton("4", OnDigitClick, 0, 9);
         AddButton("5", OnDigitClick, 1, 9);
@@ -157,7 +157,7 @@ public partial class MainForm
         AddButton("3", OnDigitClick, 2, 10);
         AddButton("+", OnOperatorClick, 3, 10);
 
-        AddButton("\\u00B1", OnToggleSignClick, 0, 11);
+        AddButton("\u00B1", OnToggleSignClick, 0, 11);
         AddButton("0", OnDigitClick, 1, 11);
         AddButton(",", OnDecimalClick, 2, 11);
         AddButton("=", OnEqualsClick, 3, 11);
@@ -169,7 +169,7 @@ public partial class MainForm
         FormBorderStyle = FormBorderStyle.FixedDialog;
         MaximizeBox = false;
         StartPosition = FormStartPosition.CenterScreen;
-        Text = "Grafikus Sz\\u00E1mol\\u00F3g\\u00E9p";
+        Text = "Grafikus Számológép";
 
         ResumeLayout(false);
 

--- a/GraphCalc/MainForm.cs
+++ b/GraphCalc/MainForm.cs
@@ -262,7 +262,7 @@ public partial class MainForm : Form
         }
 
         var operationText = string.IsNullOrWhiteSpace(OperationLabel.Text)
-            ? "Eredm\u00E9ny ="
+            ? "Eredmény ="
             : OperationLabel.Text.Trim();
         var resultText = FormatDouble(value);
         AddToMemory(new MemoryEntry(operationText, resultText));


### PR DESCRIPTION
## Summary
- replace escaped Unicode sequences in the calculator UI with their intended Hungarian labels and math symbols
- ensure the square root, multiplication, division, backspace, and sign toggle buttons display the correct glyphs
- update memory text defaults to use proper Hungarian accents

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68e0f8c19078832599da6b18946e6d70